### PR TITLE
Adds yaml support and multi-term

### DIFF
--- a/customizations/my-term.el
+++ b/customizations/my-term.el
@@ -1,0 +1,2 @@
+(require 'multi-term)
+(setq multi-term-program "/bin/bash")

--- a/customizations/web.el
+++ b/customizations/web.el
@@ -1,5 +1,11 @@
+;; handles syntax for various web formats
+
+
 (require 'web-mode)
 (add-to-list 'auto-mode-alist '("\\.html?\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.css?\\'" . web-mode))
 (setq web-mode-markup-indent-offset 2)
 (setq web-mode-css-indent-offset 4)
+
+(require 'yaml-mode)
+(add-to-list 'auto-mode-alist '("\\.yml\\'" . yaml-mode))

--- a/init.el
+++ b/init.el
@@ -37,7 +37,9 @@
     yasnippet
     clojure-snippets
     web-mode
-    nyan-mode))
+    nyan-mode
+    yaml-mode
+    multi-term))
 
 ;; Get all the packages!
 (dolist (p my-packages)
@@ -67,6 +69,7 @@
 (load "fonts.el")
 (load "snippets.el")
 (load "web.el")
+(load "my-term.el")
 (custom-set-variables
  ;; custom-set-variables was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.
@@ -80,7 +83,7 @@
  '(inhibit-startup-screen t)
  '(package-selected-packages
    (quote
-    (web-mode dash paredit neotree multiple-cursors company clojure-mode-extra-font-locking cider))))
+    (yaml-mode web-mode dash paredit neotree multiple-cursors company clojure-mode-extra-font-locking cider))))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.


### PR DESCRIPTION
Submitting as a pull request because I don't know how I feel about this yet.

`multi-term` is super useful because I regularly want multiple terminals within emacs so I don't have to leave. It is a little more opinionated about staying in `char` mode and disables `C-c` by default so there is no convenient keybinding for leaving the terminal buffer. Instead you have to be explicit with `M-x switch-to-buffer` when you want to leave. Maybe this is fine. Going to try this out for a bit and see how I feel about it.